### PR TITLE
Export all classes in index.js

### DIFF
--- a/dist/formatter.js
+++ b/dist/formatter.js
@@ -63,9 +63,9 @@ var Formatter = function () {
 
             if (metadataObj) {
               // Each field of log needs to appended with '0x' to be parsed
-              item.address = _utils2.default.formatHexStr(item.address);
-              item.data = _utils2.default.formatHexStr(item.data);
-              item.topics = _lodash2.default.map(item.topics, _utils2.default.formatHexStr);
+              item.address = _utils2.default.appendHexPrefix(item.address);
+              item.data = _utils2.default.appendHexPrefix(item.data);
+              item.topics = _lodash2.default.map(item.topics, _utils2.default.appendHexPrefix);
 
               var methodAbi = _lodash2.default.find(metadataObj.abi, { name: eventName });
               if (_lodash2.default.isUndefined(methodAbi)) {
@@ -125,7 +125,7 @@ var Formatter = function () {
       _lodash2.default.each(rawOutput, function (value, key) {
         if (key === 'executionResult') {
           var resultObj = rawOutput[key];
-          var decodedOutput = _ethjsAbi2.default.decodeMethod(methodABI[0], _utils2.default.formatHexStr(resultObj.output));
+          var decodedOutput = _ethjsAbi2.default.decodeMethod(methodABI[0], _utils2.default.appendHexPrefix(resultObj.output));
 
           // Strip hex prefix
           if (removeHexPrefix) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.Contract = exports.Qweb3 = undefined;
+exports.Utils = exports.Decoder = exports.Contract = exports.Qweb3 = undefined;
 
 var _qweb = require('./qweb3');
 
@@ -12,6 +12,14 @@ var _qweb2 = _interopRequireDefault(_qweb);
 var _contract = require('./contract');
 
 var _contract2 = _interopRequireDefault(_contract);
+
+var _decoder = require('./decoder');
+
+var _decoder2 = _interopRequireDefault(_decoder);
+
+var _utils = require('./utils');
+
+var _utils2 = _interopRequireDefault(_utils);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
@@ -22,3 +30,5 @@ if (typeof window !== 'undefined' && typeof window.Qweb3 === 'undefined') {
 
 exports.Qweb3 = _qweb2.default;
 exports.Contract = _contract2.default;
+exports.Decoder = _decoder2.default;
+exports.Utils = _utils2.default;

--- a/dist/index.js
+++ b/dist/index.js
@@ -3,7 +3,7 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.Utils = exports.Decoder = exports.Contract = exports.Qweb3 = undefined;
+exports.Utils = exports.Decoder = exports.Contract = undefined;
 
 var _qweb = require('./qweb3');
 
@@ -28,7 +28,7 @@ if (typeof window !== 'undefined' && typeof window.Qweb3 === 'undefined') {
   window.Qweb3 = _qweb2.default;
 }
 
-exports.Qweb3 = _qweb2.default;
+exports.default = _qweb2.default;
 exports.Contract = _contract2.default;
 exports.Decoder = _decoder2.default;
 exports.Utils = _utils2.default;

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,10 +1,24 @@
 'use strict';
 
-var Qweb3 = require('./qweb3');
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.Contract = exports.Qweb3 = undefined;
+
+var _qweb = require('./qweb3');
+
+var _qweb2 = _interopRequireDefault(_qweb);
+
+var _contract = require('./contract');
+
+var _contract2 = _interopRequireDefault(_contract);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 // dont override global variable
 if (typeof window !== 'undefined' && typeof window.Qweb3 === 'undefined') {
-    window.Qweb3 = Qweb3;
+  window.Qweb3 = _qweb2.default;
 }
 
-module.exports = Qweb3;
+exports.Qweb3 = _qweb2.default;
+exports.Contract = _contract2.default;

--- a/dist/qweb3.js
+++ b/dist/qweb3.js
@@ -1,5 +1,9 @@
 'use strict';
 
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _lodash = require('lodash');
@@ -293,4 +297,4 @@ var Qweb3 = function () {
   return Qweb3;
 }();
 
-module.exports = Qweb3;
+exports.default = Qweb3;

--- a/dist/utils.js
+++ b/dist/utils.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
 var _lodash = require('lodash');
 
@@ -20,329 +20,233 @@ var _web3Utils2 = _interopRequireDefault(_web3Utils);
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
-/**
- * Should be called to get utf8 from it's hex representation
- *
- * @method toUtf8
- * @param {String} string in hex
- * @returns {String} ascii string representation of hex value
- */
-var toUtf8 = function toUtf8(hex) {
-  // Find termination
-  var str = "";
-  var i = 0,
-      l = hex.length;
-  if (hex.substring(0, 2) === '0x') {
-    i = 2;
-  }
-  for (; i < l; i += 2) {
-    var code = parseInt(hex.substr(i, 2), 16);
-    if (code === 0) break;
-    str += String.fromCharCode(code);
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+var Utils = function () {
+  function Utils() {
+    _classCallCheck(this, Utils);
   }
 
-  return _utf2.default.decode(str);
-};
+  _createClass(Utils, null, [{
+    key: 'paramsCheck',
 
-/**
- * Should be called to get hex representation (prefixed by 0x) of utf8 string
- *
- * @method fromUtf8
- * @param {String} string
- * @param {Number} optional padding
- * @returns {String} hex representation of input string
- */
-var fromUtf8 = function fromUtf8(str) {
-  str = _utf2.default.encode(str);
-  var hex = "";
-  for (var i = 0; i < str.length; i++) {
-    var code = str.charCodeAt(i);
-    if (code === 0) break;
-    var n = code.toString(16);
-    hex += n.length < 2 ? '0' + n : n;
-  }
+    /**
+     * Parameter check at the beginning of a function
+     * Throw errors if required keys are missing in params object
+     * @param  {string} methodName Function name used for error message
+     * @param  {object} params     params object
+     * @param  {array} required    Array of key strings in params, e.g. ['resultNames', 'sender']
+     * @param  {func} validators  Custom functions used to validate params
+     * @return {}
+     */
+    value: function paramsCheck(methodName, params, required, validators) {
+      if (_lodash2.default.isUndefined(params)) {
+        throw new Error('params is undefined in params of ' + methodName + '; expected: ' + (_lodash2.default.isEmpty(required) ? undefined : required.join(',')));
+      }
 
-  return "0x" + hex;
-};
-
-/**
- * Should be called to get hex representation (prefixed by 0x) of ascii string
- *
- * @method fromAscii
- * @param {String} string
- * @param {Number} optional padding
- * @returns {String} hex representation of input string
- */
-var fromAscii = function fromAscii(str) {
-  var hex = "";
-  for (var i = 0; i < str.length; i++) {
-    var code = str.charCodeAt(i);
-    var n = code.toString(16);
-    hex += n.length < 2 ? '0' + n : n;
-  }
-
-  return "0x" + hex;
-};
-
-/**
- * Converts value to it's hex representation
- *
- * @method fromDecimal
- * @param {String|Number|BigNumber}
- * @return {String}
- */
-var fromDecimal = function fromDecimal(value) {
-  var number = toBigNumber(value);
-  var result = number.toString(16);
-
-  return number.lessThan(0) ? '-0x' + result.substr(1) : '0x' + result;
-};
-
-/**
- * Takes an input and transforms it into an bignumber
- *
- * @method toBigNumber
- * @param {Number|String|BigNumber} a number, string, HEX string or BigNumber
- * @return {BigNumber} BigNumber
- */
-var toBigNumber = function toBigNumber(number) {
-  /*jshint maxcomplexity:5 */
-  number = number || 0;
-  if (isBigNumber(number)) return number;
-
-  if (isString(number) && (number.indexOf('0x') === 0 || number.indexOf('-0x') === 0)) {
-    return new _bignumber2.default(number.replace('0x', ''), 16);
-  }
-
-  return new _bignumber2.default(number.toString(10), 10);
-};
-
-/**
- * Returns true if object is BigNumber, otherwise false
- *
- * @method isBigNumber
- * @param {Object}
- * @return {Boolean}
- */
-var isBigNumber = function isBigNumber(object) {
-  return object instanceof _bignumber2.default || object && object.constructor && object.constructor.name === 'BigNumber';
-};
-
-/**
- * Returns true if object is string, otherwise false
- *
- * @method isString
- * @param {Object}
- * @return {Boolean}
- */
-var isString = function isString(object) {
-  return typeof object === 'string' || object && object.constructor && object.constructor.name === 'String';
-};
-
-/**
- * Returns true if object is Objet, otherwise false
- *
- * @method isObject
- * @param {Object}
- * @return {Boolean}
- */
-var isObject = function isObject(object) {
-  return object !== null && !Array.isArray(object) && (typeof object === 'undefined' ? 'undefined' : _typeof(object)) === 'object';
-};
-
-/**
- * Returns true if object is boolean, otherwise false
- *
- * @method isBoolean
- * @param {Object}
- * @return {Boolean}
- */
-var isBoolean = function isBoolean(object) {
-  return typeof object === 'boolean';
-};
-
-/**
- * Returns true if object is array, otherwise false
- *
- * @method isArray
- * @param {Object}
- * @return {Boolean}
- */
-var isArray = function isArray(object) {
-  return Array.isArray(object);
-};
-
-/**
- * Returns true if given string is valid json object
- *
- * @method isJson
- * @param {String}
- * @return {Boolean}
- */
-var isJson = function isJson(str) {
-  try {
-    return !!JSON.parse(str);
-  } catch (e) {
-    return false;
-  }
-};
-
-/**
- * Returns true if given string is a valid log topic.
- *
- * @method isTopic
- * @param {String} hex encoded topic
- * @return {Boolean}
- */
-var isTopic = function isTopic(topic) {
-  if (!/^(0x)?[0-9a-f]{64}$/i.test(topic)) {
-    return false;
-  } else if (/^(0x)?[0-9a-f]{64}$/.test(topic) || /^(0x)?[0-9A-F]{64}$/.test(topic)) {
-    return true;
-  }
-  return false;
-};
-
-/**
- * Parameter check at the beginning of a function
- * Throw errors if required keys are missing in params object
- * @param  {string} methodName Function name used for error message
- * @param  {object} params     params object
- * @param  {array} required    Array of key strings in params, e.g. ['resultNames', 'sender']
- * @param  {func} validators  Custom functions used to validate params
- * @return {}
- */
-function paramsCheck(methodName, params, required, validators) {
-  if (_lodash2.default.isUndefined(params)) {
-    throw new Error('params is undefined in params of ' + methodName + '; expected: ' + (_lodash2.default.isEmpty(required) ? undefined : required.join(',')));
-  }
-
-  if (required) {
-    if (_lodash2.default.isArray(required)) {
-      _lodash2.default.each(required, function (value) {
-        if (_lodash2.default.isUndefined(params[value])) {
-          throw new Error(value + ' is undefined in params of ' + methodName);
+      if (required) {
+        if (_lodash2.default.isArray(required)) {
+          _lodash2.default.each(required, function (value) {
+            if (_lodash2.default.isUndefined(params[value])) {
+              throw new Error(value + ' is undefined in params of ' + methodName);
+            }
+          });
+        } else if (_lodash2.default.isUndefined(params[required])) {
+          throw new Error(required + ' is undefined in params of ' + methodName);
         }
-      });
-    } else if (_lodash2.default.isUndefined(params[required])) {
-      throw new Error(required + ' is undefined in params of ' + methodName);
+      }
+
+      if (!_lodash2.default.isEmpty(validators)) {
+        _lodash2.default.each(validators, function (validFunc, key) {
+          // Check whether each validator is a function
+          if (typeof validFunc !== 'function') {
+            throw new Error('validators are defined but not functions ...');
+          }
+
+          // Check whether key defined in validator is in params
+          if (_lodash2.default.indexOf(params, key) < 0) {
+            throw new Error(key + ' in validator is not found in params.');
+          }
+
+          // Run validator funcs and check result
+          // If result === 'undefined', pass; otherwise throw error with message
+          var error = validFunc(params[key], key);
+          if (error instanceof Error) {
+            throw new Error('validation for ' + key + ' failed; message:' + error.message);
+          }
+        });
+      }
     }
-  }
 
-  if (!_lodash2.default.isEmpty(validators)) {
-    _lodash2.default.each(validators, function (validFunc, key) {
-      // Check whether each validator is a function
-      if (typeof validFunc !== 'function') {
-        throw new Error('validators are defined but not functions ...');
+    /**
+     * Validate format string and append '0x' to it if there's not one.
+     * @param  {string} value  Hex string to format
+     * @return {string}
+     */
+
+  }, {
+    key: 'appendHexPrefix',
+    value: function appendHexPrefix(value) {
+      if (_lodash2.default.startsWith(value, '0x')) {
+        return value;
+      } else {
+        return "0x" + value;
+      }
+    }
+
+    /*
+    * Removes the '0x' hex prefix if necessary.
+    * @param str The string to remove the prefix from.
+    * @return The str without the hex prefix.
+    */
+
+  }, {
+    key: 'trimHexPrefix',
+    value: function trimHexPrefix(str) {
+      if (str && str.indexOf('0x') === 0) {
+        return str.slice(2);
+      } else {
+        return str;
+      }
+    }
+
+    /*
+     * Breaks down a string by {length} and returns an array of string
+     * @param {string} Input string
+     * @param {number} Length of each chunk.
+     * @return {array} broken-down string array
+     */
+
+  }, {
+    key: 'chunkString',
+    value: function chunkString(str, length) {
+      return str.match(new RegExp('.{1,' + length + '}', 'g'));
+    }
+
+    /**
+     * Should be called to get utf8 from it's hex representation
+     *
+     * @method toUtf8
+     * @param {String} string in hex
+     * @returns {String} ascii string representation of hex value
+     */
+
+  }, {
+    key: 'toUtf8',
+    value: function toUtf8(hex) {
+      // Find termination
+      var str = "";
+      var i = 0,
+          l = hex.length;
+      if (hex.substring(0, 2) === '0x') {
+        i = 2;
+      }
+      for (; i < l; i += 2) {
+        var code = parseInt(hex.substr(i, 2), 16);
+        if (code === 0) break;
+        str += String.fromCharCode(code);
       }
 
-      // Check whether key defined in validator is in params
-      if (_lodash2.default.indexOf(params, key) < 0) {
-        throw new Error(key + ' in validator is not found in params.');
+      return _utf2.default.decode(str);
+    }
+
+    /**
+     * Should be called to get hex representation (prefixed by 0x) of utf8 string
+     *
+     * @method fromUtf8
+     * @param {String} string
+     * @param {Number} optional padding
+     * @returns {String} hex representation of input string
+     */
+
+  }, {
+    key: 'fromUtf8',
+    value: function fromUtf8(str) {
+      str = _utf2.default.encode(str);
+      var hex = "";
+      for (var i = 0; i < str.length; i++) {
+        var code = str.charCodeAt(i);
+        if (code === 0) break;
+        var n = code.toString(16);
+        hex += n.length < 2 ? '0' + n : n;
       }
 
-      // Run validator funcs and check result
-      // If result === 'undefined', pass; otherwise throw error with message
-      var error = validFunc(params[key], key);
-      if (error instanceof Error) {
-        throw new Error('validation for ' + key + ' failed; message:' + error.message);
+      return "0x" + hex;
+    }
+
+    /**
+     * Converts value to it's hex representation
+     *
+     * @method fromDecimal
+     * @param {String|Number|BigNumber}
+     * @return {String}
+     */
+
+  }, {
+    key: 'fromDecimal',
+    value: function fromDecimal(value) {
+      var number = toBigNumber(value);
+      var result = number.toString(16);
+
+      return number.lessThan(0) ? '-0x' + result.substr(1) : '0x' + result;
+    }
+
+    /**
+     * Takes an input and transforms it into an bignumber
+     *
+     * @method toBigNumber
+     * @param {Number|String|BigNumber} a number, string, HEX string or BigNumber
+     * @return {BigNumber} BigNumber
+     */
+
+  }, {
+    key: 'toBigNumber',
+    value: function toBigNumber(number) {
+      /*jshint maxcomplexity:5 */
+      number = number || 0;
+      if (isBigNumber(number)) return number;
+
+      if (_lodash2.default.isString(number) && (number.indexOf('0x') === 0 || number.indexOf('-0x') === 0)) {
+        return new _bignumber2.default(number.replace('0x', ''), 16);
       }
-    });
-  }
-}
 
-/**
- * Auto converts any given value into it's hex representation.
- *
- * And even stringifys objects before.
- *
- * @method toHex
- * @param {String|Number|BigNumber|Object}
- * @return {String}
- */
-function toHex(val) {
-  /*jshint maxcomplexity: 8 */
+      return new _bignumber2.default(number.toString(10), 10);
+    }
 
-  if (_lodash2.default.isBoolean(val)) return fromDecimal(+val);
+    /**
+     * Returns true if object is BigNumber, otherwise false
+     *
+     * @method isBigNumber
+     * @param {Object}
+     * @return {Boolean}
+     */
 
-  if (isBigNumber(val)) return fromDecimal(val);
+  }, {
+    key: 'isBigNumber',
+    value: function isBigNumber(object) {
+      return object instanceof _bignumber2.default || object && object.constructor && object.constructor.name === 'BigNumber';
+    }
 
-  if ((typeof val === 'undefined' ? 'undefined' : _typeof(val)) === 'object') return fromUtf8(JSON.stringify(val));
+    /**
+     * Returns true if given string is valid json object
+     *
+     * @method isJson
+     * @param {String}
+     * @return {Boolean}
+     */
 
-  // if its a negative number, pass it through fromDecimal
-  if (isString(val)) {
-    if (val.indexOf('-0x') === 0) return fromDecimal(val);else if (val.indexOf('0x') === 0) return val;else if (!isFinite(val)) return fromAscii(val);
-  }
+  }, {
+    key: 'isJson',
+    value: function isJson(str) {
+      try {
+        return !!JSON.parse(str);
+      } catch (e) {
+        return false;
+      }
+    }
+  }]);
 
-  return fromDecimal(val);
-};
+  return Utils;
+}();
 
-/**
- * Validate format string and append '0x' to it if there's not one.
- * @param  {string} value  Hex string to format
- * @return {string}
- */
-function formatHexStr(value) {
-  // TODO: validate format of hex string
-  if (_lodash2.default.startsWith(value, '0x')) {
-    return value;
-  } else {
-    return "0x" + value;
-  }
-}
-
-/**
- * Should be called to get ascii from it's hex representation
- *
- * @method toAscii
- * @param {String} string in hex
- * @returns {String} ascii string representation of hex value
- */
-function toAscii(hex) {
-  // Find termination
-  var str = "";
-  var i = 0,
-      l = hex.length;
-  if (hex.substring(0, 2) === '0x') {
-    i = 2;
-  }
-  for (; i < l; i += 2) {
-    var code = parseInt(hex.substr(i, 2), 16);
-    str += String.fromCharCode(code);
-  }
-
-  return str;
-};
-
-/*
-* Removes the '0x' hex prefix if necessary.
-* @param str The string to remove the prefix from.
-* @return The str without the hex prefix.
-*/
-function trimHexPrefix(str) {
-  if (str && str.indexOf('0x') === 0) {
-    return str.slice(2);
-  } else {
-    return str;
-  }
-}
-
-/*
- * Breaks down a string by {length} and returns an array of string
- * @param {string} Input string
- * @param {number} Length of each chunk.
- * @return {array} broken-down string array
- */
-function chunkString(str, length) {
-  return str.match(new RegExp('.{1,' + length + '}', 'g'));
-}
-
-module.exports = {
-  paramsCheck: paramsCheck,
-  toHex: toHex,
-  formatHexStr: formatHexStr,
-  toUtf8: toUtf8,
-  toAscii: toAscii,
-  trimHexPrefix: trimHexPrefix,
-  chunkString: chunkString
-};
+module.exports = Utils;

--- a/src/formatter.js
+++ b/src/formatter.js
@@ -34,9 +34,9 @@ class Formatter {
 
           if (metadataObj) {
             // Each field of log needs to appended with '0x' to be parsed
-            item.address = Utils.formatHexStr(item.address);
-            item.data = Utils.formatHexStr(item.data);
-            item.topics = _.map(item.topics, Utils.formatHexStr);
+            item.address = Utils.appendHexPrefix(item.address);
+            item.data = Utils.appendHexPrefix(item.data);
+            item.topics = _.map(item.topics, Utils.appendHexPrefix);
 
             const methodAbi = _.find(metadataObj.abi, { name: eventName });
             if (_.isUndefined(methodAbi)) {
@@ -92,7 +92,7 @@ class Formatter {
     _.each(rawOutput, (value, key) => {
       if (key === 'executionResult') {
         const resultObj = rawOutput[key];
-        const decodedOutput = EthjsAbi.decodeMethod(methodABI[0], Utils.formatHexStr(resultObj.output));
+        const decodedOutput = EthjsAbi.decodeMethod(methodABI[0], Utils.appendHexPrefix(resultObj.output));
 
         // Strip hex prefix
         if (removeHexPrefix) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,12 @@
-var Qweb3 = require('./qweb3');
+import Qweb3 from './qweb3';
+import Contract from './contract';
 
 // dont override global variable
 if (typeof window !== 'undefined' && typeof window.Qweb3 === 'undefined') {
-    window.Qweb3 = Qweb3;
+  window.Qweb3 = Qweb3;
 }
 
-module.exports = Qweb3;
+export {
+  Qweb3,
+  Contract
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 import Qweb3 from './qweb3';
 import Contract from './contract';
+import Decoder from './decoder';
+import Utils from './utils';
 
 // dont override global variable
 if (typeof window !== 'undefined' && typeof window.Qweb3 === 'undefined') {
@@ -8,5 +10,7 @@ if (typeof window !== 'undefined' && typeof window.Qweb3 === 'undefined') {
 
 export {
   Qweb3,
-  Contract
+  Contract,
+  Decoder,
+  Utils
 };

--- a/src/index.js
+++ b/src/index.js
@@ -8,8 +8,8 @@ if (typeof window !== 'undefined' && typeof window.Qweb3 === 'undefined') {
   window.Qweb3 = Qweb3;
 }
 
+export default Qweb3;
 export {
-  Qweb3,
   Contract,
   Decoder,
   Utils

--- a/src/qweb3.js
+++ b/src/qweb3.js
@@ -233,4 +233,4 @@ class Qweb3 {
   }
 }
 
-module.exports = Qweb3;
+export default Qweb3;

--- a/src/utils.js
+++ b/src/utils.js
@@ -3,342 +3,199 @@ import BigNumber from 'bignumber.js';
 import utf8 from 'utf8';
 import Web3Utils from 'web3-utils';
 
-/**
- * Should be called to get utf8 from it's hex representation
- *
- * @method toUtf8
- * @param {String} string in hex
- * @returns {String} ascii string representation of hex value
- */
-var toUtf8 = function(hex) {
-  // Find termination
-  var str = "";
-  var i = 0,
-    l = hex.length;
-  if (hex.substring(0, 2) === '0x') {
-    i = 2;
-  }
-  for (; i < l; i += 2) {
-    var code = parseInt(hex.substr(i, 2), 16);
-    if (code === 0)
-      break;
-    str += String.fromCharCode(code);
-  }
+class Utils {
+  /**
+   * Parameter check at the beginning of a function
+   * Throw errors if required keys are missing in params object
+   * @param  {string} methodName Function name used for error message
+   * @param  {object} params     params object
+   * @param  {array} required    Array of key strings in params, e.g. ['resultNames', 'sender']
+   * @param  {func} validators  Custom functions used to validate params
+   * @return {}
+   */
+  static paramsCheck(methodName, params, required, validators) {
+    if (_.isUndefined(params)) {
+      throw new Error(`params is undefined in params of ${methodName}; expected: ${_.isEmpty(required) 
+        ? undefined : required.join(',')}`);
+    }
 
-  return utf8.decode(str);
-};
+    if (required) {
+      if (_.isArray(required)) {
+        _.each(required, (value) => {
+          if (_.isUndefined(params[value])) {
+            throw new Error(`${value} is undefined in params of ${methodName}`);
+          }
+        });
+      } else if (_.isUndefined(params[required])) {
+        throw new Error(`${required} is undefined in params of ${methodName}`);
+      }
+    }
 
-/**
- * Should be called to get hex representation (prefixed by 0x) of utf8 string
- *
- * @method fromUtf8
- * @param {String} string
- * @param {Number} optional padding
- * @returns {String} hex representation of input string
- */
-var fromUtf8 = function(str) {
-  str = utf8.encode(str);
-  var hex = "";
-  for (var i = 0; i < str.length; i++) {
-    var code = str.charCodeAt(i);
-    if (code === 0)
-      break;
-    var n = code.toString(16);
-    hex += n.length < 2 ? '0' + n : n;
-  }
+    if (!_.isEmpty(validators)) {
+      _.each(validators, (validFunc, key) => {
+        // Check whether each validator is a function
+        if (typeof validFunc !== 'function') {
+          throw new Error('validators are defined but not functions ...');
+        }
 
-  return "0x" + hex;
-};
+        // Check whether key defined in validator is in params
+        if (_.indexOf(params, key) < 0) {
+          throw new Error(`${key} in validator is not found in params.`);
+        }
 
-/**
- * Should be called to get hex representation (prefixed by 0x) of ascii string
- *
- * @method fromAscii
- * @param {String} string
- * @param {Number} optional padding
- * @returns {String} hex representation of input string
- */
-var fromAscii = function(str) {
-  var hex = "";
-  for (var i = 0; i < str.length; i++) {
-    var code = str.charCodeAt(i);
-    var n = code.toString(16);
-    hex += n.length < 2 ? '0' + n : n;
-  }
-
-  return "0x" + hex;
-};
-
-/**
- * Converts value to it's hex representation
- *
- * @method fromDecimal
- * @param {String|Number|BigNumber}
- * @return {String}
- */
-var fromDecimal = function(value) {
-  var number = toBigNumber(value);
-  var result = number.toString(16);
-
-  return number.lessThan(0) ? '-0x' + result.substr(1) : '0x' + result;
-};
-
-/**
- * Takes an input and transforms it into an bignumber
- *
- * @method toBigNumber
- * @param {Number|String|BigNumber} a number, string, HEX string or BigNumber
- * @return {BigNumber} BigNumber
- */
-var toBigNumber = function(number) {
-  /*jshint maxcomplexity:5 */
-  number = number || 0;
-  if (isBigNumber(number))
-    return number;
-
-  if (isString(number) && (number.indexOf('0x') === 0 || number.indexOf('-0x') === 0)) {
-    return new BigNumber(number.replace('0x', ''), 16);
-  }
-
-  return new BigNumber(number.toString(10), 10);
-};
-
-/**
- * Returns true if object is BigNumber, otherwise false
- *
- * @method isBigNumber
- * @param {Object}
- * @return {Boolean}
- */
-var isBigNumber = function(object) {
-  return object instanceof BigNumber ||
-    (object && object.constructor && object.constructor.name === 'BigNumber');
-};
-
-/**
- * Returns true if object is string, otherwise false
- *
- * @method isString
- * @param {Object}
- * @return {Boolean}
- */
-var isString = function(object) {
-  return typeof object === 'string' ||
-    (object && object.constructor && object.constructor.name === 'String');
-};
-
-/**
- * Returns true if object is Objet, otherwise false
- *
- * @method isObject
- * @param {Object}
- * @return {Boolean}
- */
-var isObject = function(object) {
-  return object !== null && !(Array.isArray(object)) && typeof object === 'object';
-};
-
-/**
- * Returns true if object is boolean, otherwise false
- *
- * @method isBoolean
- * @param {Object}
- * @return {Boolean}
- */
-var isBoolean = function(object) {
-  return typeof object === 'boolean';
-};
-
-/**
- * Returns true if object is array, otherwise false
- *
- * @method isArray
- * @param {Object}
- * @return {Boolean}
- */
-var isArray = function(object) {
-  return Array.isArray(object);
-};
-
-/**
- * Returns true if given string is valid json object
- *
- * @method isJson
- * @param {String}
- * @return {Boolean}
- */
-var isJson = function(str) {
-  try {
-    return !!JSON.parse(str);
-  } catch (e) {
-    return false;
-  }
-};
-
-/**
- * Returns true if given string is a valid log topic.
- *
- * @method isTopic
- * @param {String} hex encoded topic
- * @return {Boolean}
- */
-var isTopic = function(topic) {
-  if (!/^(0x)?[0-9a-f]{64}$/i.test(topic)) {
-    return false;
-  } else if (/^(0x)?[0-9a-f]{64}$/.test(topic) || /^(0x)?[0-9A-F]{64}$/.test(topic)) {
-    return true;
-  }
-  return false;
-};
-
-/**
- * Parameter check at the beginning of a function
- * Throw errors if required keys are missing in params object
- * @param  {string} methodName Function name used for error message
- * @param  {object} params     params object
- * @param  {array} required    Array of key strings in params, e.g. ['resultNames', 'sender']
- * @param  {func} validators  Custom functions used to validate params
- * @return {}
- */
-function paramsCheck(methodName, params, required, validators) {
-  if (_.isUndefined(params)) {
-    throw new Error(`params is undefined in params of ${methodName}; expected: ${_.isEmpty(required) ? undefined : required.join(',')}`);
-  }
-
-  if (required) {
-    if (_.isArray(required)) {
-      _.each(required, (value) => {
-        if (_.isUndefined(params[value])) {
-          throw new Error(`${value} is undefined in params of ${methodName}`);
+        // Run validator funcs and check result
+        // If result === 'undefined', pass; otherwise throw error with message
+        const error = validFunc(params[key], key);
+        if (error instanceof Error) {
+          throw new Error(`validation for ${key} failed; message:${error.message}`);
         }
       });
-    } else if (_.isUndefined(params[required])) {
-      throw new Error(`${required} is undefined in params of ${methodName}`);
     }
   }
 
-  if (!_.isEmpty(validators)) {
-    _.each(validators, (validFunc, key) => {
-      // Check whether each validator is a function
-      if (typeof validFunc !== 'function') {
-        throw new Error('validators are defined but not functions ...');
-      }
+  /**
+   * Validate format string and append '0x' to it if there's not one.
+   * @param  {string} value  Hex string to format
+   * @return {string}
+   */
+  static appendHexPrefix(value) {
+    if (_.startsWith(value, '0x')) {
+      return value;
+    } else {
+      return "0x" + value;
+    }
+  }
 
-      // Check whether key defined in validator is in params
-      if (_.indexOf(params, key) < 0) {
-        throw new Error(`${key} in validator is not found in params.`);
-      }
+  /*
+  * Removes the '0x' hex prefix if necessary.
+  * @param str The string to remove the prefix from.
+  * @return The str without the hex prefix.
+  */
+  static trimHexPrefix(str) {
+    if (str && str.indexOf('0x') === 0) {
+      return str.slice(2);
+    } else {
+      return str;
+    }
+  }
 
-      // Run validator funcs and check result
-      // If result === 'undefined', pass; otherwise throw error with message
-      const error = validFunc(params[key], key);
-      if (error instanceof Error) {
-        throw new Error(`validation for ${key} failed; message:${error.message}`);
-      }
-    });
+  /*
+   * Breaks down a string by {length} and returns an array of string
+   * @param {string} Input string
+   * @param {number} Length of each chunk.
+   * @return {array} broken-down string array
+   */
+  static chunkString(str, length) {
+    return str.match(new RegExp('.{1,' + length + '}', 'g'));
+  }
+
+  /**
+   * Should be called to get utf8 from it's hex representation
+   *
+   * @method toUtf8
+   * @param {String} string in hex
+   * @returns {String} ascii string representation of hex value
+   */
+  static toUtf8(hex) {
+    // Find termination
+    var str = "";
+    var i = 0,
+      l = hex.length;
+    if (hex.substring(0, 2) === '0x') {
+      i = 2;
+    }
+    for (; i < l; i += 2) {
+      var code = parseInt(hex.substr(i, 2), 16);
+      if (code === 0)
+        break;
+      str += String.fromCharCode(code);
+    }
+
+    return utf8.decode(str);
+  }
+
+  /**
+   * Should be called to get hex representation (prefixed by 0x) of utf8 string
+   *
+   * @method fromUtf8
+   * @param {String} string
+   * @param {Number} optional padding
+   * @returns {String} hex representation of input string
+   */
+  static fromUtf8(str) {
+    str = utf8.encode(str);
+    var hex = "";
+    for (var i = 0; i < str.length; i++) {
+      var code = str.charCodeAt(i);
+      if (code === 0)
+        break;
+      var n = code.toString(16);
+      hex += n.length < 2 ? '0' + n : n;
+    }
+
+    return "0x" + hex;
+  }
+
+  /**
+   * Converts value to it's hex representation
+   *
+   * @method fromDecimal
+   * @param {String|Number|BigNumber}
+   * @return {String}
+   */
+  static fromDecimal(value) {
+    var number = toBigNumber(value);
+    var result = number.toString(16);
+
+    return number.lessThan(0) ? '-0x' + result.substr(1) : '0x' + result;
+  }
+
+  /**
+   * Takes an input and transforms it into an bignumber
+   *
+   * @method toBigNumber
+   * @param {Number|String|BigNumber} a number, string, HEX string or BigNumber
+   * @return {BigNumber} BigNumber
+   */
+  static toBigNumber(number) {
+    /*jshint maxcomplexity:5 */
+    number = number || 0;
+    if (isBigNumber(number))
+      return number;
+
+    if (_.isString(number) && (number.indexOf('0x') === 0 || number.indexOf('-0x') === 0)) {
+      return new BigNumber(number.replace('0x', ''), 16);
+    }
+
+    return new BigNumber(number.toString(10), 10);
+  }
+
+  /**
+   * Returns true if object is BigNumber, otherwise false
+   *
+   * @method isBigNumber
+   * @param {Object}
+   * @return {Boolean}
+   */
+  static isBigNumber(object) {
+    return object instanceof BigNumber ||
+      (object && object.constructor && object.constructor.name === 'BigNumber');
+  }
+
+  /**
+   * Returns true if given string is valid json object
+   *
+   * @method isJson
+   * @param {String}
+   * @return {Boolean}
+   */
+  static isJson(str) {
+    try {
+      return !!JSON.parse(str);
+    } catch (e) {
+      return false;
+    }
   }
 }
 
-/**
- * Auto converts any given value into it's hex representation.
- *
- * And even stringifys objects before.
- *
- * @method toHex
- * @param {String|Number|BigNumber|Object}
- * @return {String}
- */
-function toHex(val) {
-  /*jshint maxcomplexity: 8 */
-
-  if (_.isBoolean(val))
-    return fromDecimal(+val);
-
-  if (isBigNumber(val))
-    return fromDecimal(val);
-
-  if (typeof val === 'object')
-    return fromUtf8(JSON.stringify(val));
-
-  // if its a negative number, pass it through fromDecimal
-  if (isString(val)) {
-    if (val.indexOf('-0x') === 0)
-      return fromDecimal(val);
-    else if (val.indexOf('0x') === 0)
-      return val;
-    else if (!isFinite(val))
-      return fromAscii(val);
-  }
-
-  return fromDecimal(val);
-};
-
-/**
- * Validate format string and append '0x' to it if there's not one.
- * @param  {string} value  Hex string to format
- * @return {string}
- */
-function formatHexStr(value) {
-  // TODO: validate format of hex string
-  if (_.startsWith(value, '0x')) {
-    return value;
-  } else {
-    return "0x" + value;
-  }
-}
-
-/**
- * Should be called to get ascii from it's hex representation
- *
- * @method toAscii
- * @param {String} string in hex
- * @returns {String} ascii string representation of hex value
- */
-function toAscii(hex) {
-  // Find termination
-  var str = "";
-  var i = 0,
-    l = hex.length;
-  if (hex.substring(0, 2) === '0x') {
-    i = 2;
-  }
-  for (; i < l; i += 2) {
-    var code = parseInt(hex.substr(i, 2), 16);
-    str += String.fromCharCode(code);
-  }
-
-  return str;
-};
-
-/*
-* Removes the '0x' hex prefix if necessary.
-* @param str The string to remove the prefix from.
-* @return The str without the hex prefix.
-*/
-function trimHexPrefix(str) {
-  if (str && str.indexOf('0x') === 0) {
-    return str.slice(2);
-  } else {
-    return str;
-  }
-}
-
-/*
- * Breaks down a string by {length} and returns an array of string
- * @param {string} Input string
- * @param {number} Length of each chunk.
- * @return {array} broken-down string array
- */
-function chunkString(str, length) {
-  return str.match(new RegExp('.{1,' + length + '}', 'g'));
-}
-
-module.exports = {
-  paramsCheck: paramsCheck,
-  toHex: toHex,
-  formatHexStr: formatHexStr,
-  toUtf8: toUtf8,
-  toAscii: toAscii,
-  trimHexPrefix: trimHexPrefix,
-  chunkString: chunkString,
-};
+module.exports = Utils;


### PR DESCRIPTION
 Let's include this in the 0.2.6 npm module update. This is so we won't need to specify path to `Contract` class like `import Contract from 'qweb3/dist/contract'` > `import { Contract } from 'qweb3'`.