### PR TITLE
uintToHex bug

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "qweb3",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1485,6 +1485,11 @@
         "tweetnacl": "0.14.5"
       }
     },
+    "bignumber.js": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-5.0.0.tgz",
+      "integrity": "sha512-KWTu6ZMVk9sxlDJQh2YH1UOnfDP8O8TpxUxgQG/vKASoSnEjK9aVuOueFaPcQEYQ5fyNXNTOYwYw3099RYebWg=="
+    },
     "binary-extensions": {
       "version": "1.11.0",
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.11.0.tgz",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "qweb3",
   "namespace": "bodhi",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Qtum JavaScript API comunicating to qtum node over RPC",
   "main": "./dist/index.js",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -17,8 +17,8 @@
     "npm": "5.5.1"
   },
   "dependencies": {
+    "bignumber.js": "^5.0.0",
     "bluebird": "^3.5.1",
-    "bn.js": "^4.11.8",
     "bs58": "^4.0.1",
     "ethjs-abi": "^0.2.1",
     "lodash": "^4.17.4",

--- a/src/encoder.js
+++ b/src/encoder.js
@@ -76,6 +76,7 @@ class Encoder {
    * Accepts the following formats:
    *    decimal: 12345
    *    string: '-12345'
+   *    hex string (with 0x hex prefix): '0xbd614e' or 0xbd614e
    *    BN.js: <BN: 3039>
    * @param num The number to convert.
    * @return The converted int to padded-left hex string.
@@ -85,14 +86,7 @@ class Encoder {
       throw new Error('num should not be undefined');
     }
 
-    // Must be converted to Two's Complement representation to handle negative numbers
-    const twosComp = new BN(num).toTwos(256).toJSON();
-    if (_.indexOf(num.toString(), '-') === -1) {
-      // Positive ints are padded with 0
-      return Web3Utils.padLeft(twosComp, PADDED_BYTES, '0');
-    }
-    // Negative ints are padded with f
-    return Web3Utils.padLeft(twosComp, PADDED_BYTES, 'f');
+    return Web3Utils.toTwosComplement(num).slice(2);
   }
 
   /*

--- a/src/encoder.js
+++ b/src/encoder.js
@@ -1,6 +1,6 @@
 import _ from 'lodash';
 import Web3Utils from 'web3-utils';
-import BN from 'bn.js';
+import BigNumber from 'bignumber.js';
 import bs58 from 'bs58';
 
 import Utils from './utils';
@@ -99,8 +99,8 @@ class Encoder {
    * Converts a uint to hex padded-left to 32 bytes.
    * Accepts the following formats:
    *    decimal: 12345
-   *    string: '-12345'
-   *    hex string (without 0x hex prefix): 'bd614e'
+   *    string: '12345'
+   *    hex string (with 0x hex prefix): '0xbd614e' or 0xbd614e
    *    BN.js: <BN: 3039>
    * @param num The number to convert.
    * @return The converted uint to padded-left hex string.
@@ -110,7 +110,13 @@ class Encoder {
       throw new Error('num should not be undefined');
     }
 
-    const bigNum = new BN(num, 16).toJSON();
+    let bigNum;
+    if (Web3Utils.isHexStrict(num)) {
+      bigNum = new BigNumber(num, 16);
+    } else {
+      bigNum = new BigNumber(num, 10);
+    }
+    
     const hexNum = Web3Utils.numberToHex(bigNum);
     return Web3Utils.padLeft(hexNum, PADDED_BYTES).slice(2);
   }

--- a/src/encoder.js
+++ b/src/encoder.js
@@ -77,6 +77,7 @@ class Encoder {
    *    decimal: 12345
    *    string: '-12345'
    *    hex string (with 0x hex prefix): '0xbd614e' or 0xbd614e
+   *    bignumber.js: <BigNumber: 3039>
    *    BN.js: <BN: 3039>
    * @param num The number to convert.
    * @return The converted int to padded-left hex string.
@@ -95,6 +96,7 @@ class Encoder {
    *    decimal: 12345
    *    string: '12345'
    *    hex string (with 0x hex prefix): '0xbd614e' or 0xbd614e
+   *    bignumber.js: <BigNumber: 3039>
    *    BN.js: <BN: 3039>
    * @param num The number to convert.
    * @return The converted uint to padded-left hex string.

--- a/test/contract.js
+++ b/test/contract.js
@@ -71,7 +71,7 @@ describe('Contract', () => {
       const methodObj = _.find(contract.abi, { name: 'createTopic' });
       assert.isDefined(methodObj);
 
-      const args = ['qKjn4fStBaAtwGiwueJf9qFxgpbAvf1xAy', 'Hello World', ['a', 'b', 'c'], 'c350', 'c738'];
+      const args = ['qKjn4fStBaAtwGiwueJf9qFxgpbAvf1xAy', 'Hello World', ['a', 'b', 'c'], '0xc350', '0xc738'];
       const dataHex = contract.constructDataHex(methodObj, args);
 
       const funcHash = 'd0613dce';
@@ -82,8 +82,7 @@ describe('Contract', () => {
       const resultSettingEndBlock = '000000000000000000000000000000000000000000000000000000000000C738';
 
       assert.equal(dataHex, funcHash.concat(oracle).concat(name).concat(resultNames).concat(bettingEndBlock)
-        .concat(resultSettingEndBlock)
-        .toLowerCase());
+        .concat(resultSettingEndBlock).toLowerCase());
     });
 
     it('converts address types', () => {

--- a/test/encoder.js
+++ b/test/encoder.js
@@ -234,15 +234,27 @@ describe('Encoder', () => {
       assert.equal(hex, '0000000000000000000000000000000000000000000000000000000000000000');
       assert.equal(hex.length, PADDED_BYTES);
 
-      hex = Encoder.uintToHex('1000000');
-      assert.equal(hex, '00000000000000000000000000000000000000000000000000000000000f4240');
+      hex = Encoder.uintToHex(66100);
+      assert.equal(hex, '0000000000000000000000000000000000000000000000000000000000010234');
       assert.equal(hex.length, PADDED_BYTES);
 
-      hex = Encoder.uintToHex('2386f26fc10000');
+      hex = Encoder.uintToHex(1234567890);
+      assert.equal(hex, '00000000000000000000000000000000000000000000000000000000499602d2');
+      assert.equal(hex.length, PADDED_BYTES);
+
+      hex = Encoder.uintToHex('12345678901234567890');
+      assert.equal(hex, '000000000000000000000000000000000000000000000000ab54a98ceb1f0ad2');
+      assert.equal(hex.length, PADDED_BYTES);
+
+      hex = Encoder.uintToHex(0x2386f26fc10000);
       assert.equal(hex, '000000000000000000000000000000000000000000000000002386f26fc10000');
       assert.equal(hex.length, PADDED_BYTES);
 
-      hex = Encoder.uintToHex('ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff');
+      hex = Encoder.uintToHex('0x2386f26fc10000');
+      assert.equal(hex, '000000000000000000000000000000000000000000000000002386f26fc10000');
+      assert.equal(hex.length, PADDED_BYTES);
+
+      hex = Encoder.uintToHex('0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff');
       assert.equal(hex, 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff');
       assert.equal(hex.length, PADDED_BYTES);
 

--- a/test/encoder.js
+++ b/test/encoder.js
@@ -1,5 +1,6 @@
 import { assert } from 'chai';
 import BN from 'bn.js';
+import BigNumber from 'bignumber.js';
 
 import Encoder from '../src/encoder';
 
@@ -228,6 +229,14 @@ describe('Encoder', () => {
       hex = Encoder.intToHex(new BN(INT256_MIN));
       assert.equal(hex, '8000000000000000000000000000000000000000000000000000000000000000');
       assert.equal(hex.length, PADDED_BYTES);
+
+      hex = Encoder.intToHex(new BigNumber(INT256_MAX));
+      assert.equal(hex, '7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff');
+      assert.equal(hex.length, PADDED_BYTES);
+
+      hex = Encoder.intToHex(new BigNumber(INT256_MIN));
+      assert.equal(hex, '8000000000000000000000000000000000000000000000000000000000000000');
+      assert.equal(hex.length, PADDED_BYTES);
     });
 
     it('throws if num is undefined', () => {
@@ -271,6 +280,14 @@ describe('Encoder', () => {
       assert.equal(hex.length, PADDED_BYTES);
 
       hex = Encoder.uintToHex(new BN(UINT256_MIN));
+      assert.equal(hex, '0000000000000000000000000000000000000000000000000000000000000000');
+      assert.equal(hex.length, PADDED_BYTES);
+
+      hex = Encoder.uintToHex(new BigNumber(UINT256_MAX));
+      assert.equal(hex, 'ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff');
+      assert.equal(hex.length, PADDED_BYTES);
+
+      hex = Encoder.uintToHex(new BigNumber(UINT256_MIN));
       assert.equal(hex, '0000000000000000000000000000000000000000000000000000000000000000');
       assert.equal(hex.length, PADDED_BYTES);
     });

--- a/test/encoder.js
+++ b/test/encoder.js
@@ -205,6 +205,14 @@ describe('Encoder', () => {
       assert.equal(hex, '000000000000000000000000000000000000000000000000002386f26fc10000');
       assert.equal(hex.length, PADDED_BYTES);
 
+      hex = Encoder.intToHex('0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff');
+      assert.equal(hex, '7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff');
+      assert.equal(hex.length, PADDED_BYTES);
+
+      hex = Encoder.intToHex('0x8000000000000000000000000000000000000000000000000000000000000000');
+      assert.equal(hex, '8000000000000000000000000000000000000000000000000000000000000000');
+      assert.equal(hex.length, PADDED_BYTES);
+
       hex = Encoder.intToHex(INT256_MAX);
       assert.equal(hex, '7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff');
       assert.equal(hex.length, PADDED_BYTES);


### PR DESCRIPTION
- fixed edge case where hex string without 0x prefix was returning wrong number
- this is requires all hex numbers to be prefixed with 0x in order to work
- the check for hex numbers doesn't always work without the hex prefix; some number strings ('10000') can be mistaken for hex and would cause issues with Web3Utils.numberToHex()

now both intToHex() and uintToHex() can accept: 
- decimals
- number strings
- hex strings with 0x prefix
- BN.js instances
- bignumber.js instances