### PR TITLE
listaccounts command added - tests updated and some generalizated - alternatively configurable via environment variables or dotenv

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -700,6 +700,12 @@
       "resolved": "https://registry.npmjs.org/dom-walk/-/dom-walk-0.1.1.tgz",
       "integrity": "sha1-ZyIm3HTI95mtNTB9+TaroRrNYBg="
     },
+    "dotenv": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-5.0.1.tgz",
+      "integrity": "sha512-4As8uPrjfwb7VXC+WnLCbXK7y+Ueb2B3zgNCePYfhxS1PYeaO1YTeplffTEcbfLhvFNGLAz90VvJs9yomG7bow==",
+      "dev": true
+    },
     "ecc-jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -223,9 +223,10 @@
       "dev": true
     },
     "base-x": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.3.tgz",
-      "integrity": "sha512-qKXPTB94LxXhJs8hqwTdyVTiDXMFTRUFj5F7FnWOW19ALCfANf2lHHUnEcY43g3DaVi4X8E2oDCkHIN8bjr32Q==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
+      "integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
+      "dev": true,
       "requires": {
         "safe-buffer": "5.1.1"
       }
@@ -319,8 +320,9 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
       "integrity": "sha1-vhYedsNU9veIrkBx9j806MTwpCo=",
+      "dev": true,
       "requires": {
-        "base-x": "3.0.3"
+        "base-x": "3.0.4"
       }
     },
     "buffer-to-arraybuffer": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "bignumber.js": "^5.0.0",
     "bluebird": "^3.5.1",
-    "bs58": "^4.0.1",
     "ethjs-abi": "^0.2.1",
     "lodash": "^4.17.4",
     "node-fetch": "^1.7.3",
@@ -27,6 +26,7 @@
     "web3-utils": "^1.0.0-beta.26"
   },
   "devDependencies": {
+    "bs58": "^4.0.1",
     "chai": "^3.0.0",
     "dotenv": "^5.0.1",
     "eslint": "^4.11.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "devDependencies": {
     "chai": "^3.0.0",
+    "dotenv": "^5.0.1",
     "eslint": "^4.11.0",
     "eslint-config-airbnb-base": "^12.1.0",
     "eslint-plugin-import": "^2.8.0",

--- a/src/qweb3.js
+++ b/src/qweb3.js
@@ -338,6 +338,16 @@ class Qweb3 {
   }
 
   /*
+  * Lists accounts.
+  * @return {Promise} Array of accounts or Error
+  */
+  listAccounts() {
+    return this.provider.request({
+      method: 'listaccounts',
+    });
+  }
+
+  /*
   * Lists temporary unspendable outputs.
   * @return {Promise} Array of unspendable outputs or Error
   */

--- a/test/qweb3.js
+++ b/test/qweb3.js
@@ -306,7 +306,9 @@ describe('Qweb3', () => {
 
   describe('fromHexAddress()', () => {
     it('returns the qtum address', async () => {
-      assert.equal(await qweb3.fromHexAddress('17e7888aa7412a735f336d2f6d784caefabb6fa3'), QTUM_ADDRESS);
+      var qtumAddress = await qweb3.fromHexAddress('17e7888aa7412a735f336d2f6d784caefabb6fa3')
+      assert.isString(qtumAddress);
+      assert.lengthOf(qtumAddress, 34, `${qtumAddress} has length of 34`);
     });
   });
 

--- a/test/qweb3.js
+++ b/test/qweb3.js
@@ -294,6 +294,8 @@ describe('Qweb3', () => {
   /** ******** RAW TRANSACTIONS ********* */
   describe('getHexAddress()', () => {
     it('returns the hex address', async () => {
+      var ha = web3Utils.toHex(QTUM_ADDRESS)
+      var har = await qweb3.getHexAddress(QTUM_ADDRESS)
       assert.equal(await qweb3.getHexAddress(QTUM_ADDRESS), '17e7888aa7412a735f336d2f6d784caefabb6fa3');
     });
   });
@@ -437,6 +439,14 @@ describe('Qweb3', () => {
       const res = await qweb3.getUnconfirmedBalance();
       assert.isDefined(res);
       assert.isNumber(res);
+    });
+  });
+
+  describe('listAccounts()', () => {
+    it('returns an array of accounts', async () => {
+      const res = await qweb3.listAccounts();
+      assert.isDefined(res);
+      assert.isObject(res);
     });
   });
 

--- a/test/qweb3.js
+++ b/test/qweb3.js
@@ -9,12 +9,19 @@ const Formatter = require('../src/formatter');
 const Config = require('./config/config');
 const ContractMetadata = require('./data/contract_metadata');
 
+// Load some environment variables as global vars
+require('dotenv').config();
+var qtumRPCAddress = "QTUM_TESTNET_RPC_ADDRESS" in process.env ? String(new Buffer(process.env["QTUM_TESTNET_RPC_ADDRESS"])) : console.debug('QTUM_TESTNET_RPC_ADDRESS environment variable not found')
+var qtumUsername = "QTUM_TESTNET_USERNAME" in process.env ? String(new Buffer(process.env["QTUM_TESTNET_USERNAME"])) : console.debug('QTUM_TESTNET_USERNAME environment variable not found')
+var qtumPassword = "QTUM_TESTNET_PASSWORD" in process.env ? String(new Buffer(process.env["QTUM_TESTNET_PASSWORD"])) : console.debug('QTUM_TESTNET_PASSWORD environment variable not found')
+var qtumAddress = "QTUM_TESTNET_ADDRESS" in process.env ? String(new Buffer(process.env["QTUM_TESTNET_ADDRESS"])) : console.debug('QTUM_TESTNET_ADDRESS environment variable not found')
+
 describe('Qweb3', () => {
-  const QTUM_ADDRESS = 'qKjn4fStBaAtwGiwueJf9qFxgpbAvf1xAy';
+  const QTUM_ADDRESS = qtumAddress ? qtumAddress : 'qKjn4fStBaAtwGiwueJf9qFxgpbAvf1xAy';
   let qweb3;
 
   beforeEach(() => {
-    qweb3 = new Qweb3(Config.QTUM_RPC_ADDRESS);
+    qweb3 = new Qweb3( qtumRPCAddress ? qtumRPCAddress : Config.QTUM_RPC_ADDRESS);
   });
 
   /** ******** MISC ********* */

--- a/test/qweb3.js
+++ b/test/qweb3.js
@@ -12,8 +12,6 @@ const ContractMetadata = require('./data/contract_metadata');
 // Load some environment variables as global vars
 require('dotenv').config();
 var qtumRPCAddress = "QTUM_TESTNET_RPC_ADDRESS" in process.env ? String(new Buffer(process.env["QTUM_TESTNET_RPC_ADDRESS"])) : console.debug('QTUM_TESTNET_RPC_ADDRESS environment variable not found')
-var qtumUsername = "QTUM_TESTNET_USERNAME" in process.env ? String(new Buffer(process.env["QTUM_TESTNET_USERNAME"])) : console.debug('QTUM_TESTNET_USERNAME environment variable not found')
-var qtumPassword = "QTUM_TESTNET_PASSWORD" in process.env ? String(new Buffer(process.env["QTUM_TESTNET_PASSWORD"])) : console.debug('QTUM_TESTNET_PASSWORD environment variable not found')
 var qtumAddress = "QTUM_TESTNET_ADDRESS" in process.env ? String(new Buffer(process.env["QTUM_TESTNET_ADDRESS"])) : console.debug('QTUM_TESTNET_ADDRESS environment variable not found')
 
 describe('Qweb3', () => {

--- a/test/qweb3.js
+++ b/test/qweb3.js
@@ -4,6 +4,8 @@ const chai = require('chai');
 const assert = chai.assert;
 const expect = chai.expect;
 
+const bs58 = require('bs58')
+
 const Qweb3 = require('../src/qweb3');
 const Formatter = require('../src/formatter');
 const Config = require('./config/config');
@@ -294,9 +296,11 @@ describe('Qweb3', () => {
   /** ******** RAW TRANSACTIONS ********* */
   describe('getHexAddress()', () => {
     it('returns the hex address', async () => {
-      var ha = web3Utils.toHex(QTUM_ADDRESS)
-      var har = await qweb3.getHexAddress(QTUM_ADDRESS)
-      assert.equal(await qweb3.getHexAddress(QTUM_ADDRESS), '17e7888aa7412a735f336d2f6d784caefabb6fa3');
+      const hexDecodedaAddress = bs58.decode(QTUM_ADDRESS).toString('hex')
+      var hexadecimalAddress = await qweb3.getHexAddress(QTUM_ADDRESS)
+      assert.isString(hexadecimalAddress);
+      assert.lengthOf(hexadecimalAddress, 40, `${hexadecimalAddress} has length of 40`);
+      assert.include(hexDecodedaAddress, hexadecimalAddress, `${hexDecodedaAddress} contains ${hexadecimalAddress}`);
     });
   });
 


### PR DESCRIPTION
- Add **listaccounts** command
- **QTUM_RPC_ADDRESS** and **QTUM_ADDRESS** now alternatively configurable via environment variables or dotenv.
- Generalization of **getHexAddress** and **fromHexAddress** tests to work with any **QTUM_ADDRESS**.