### PR TITLE
fix engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     "lib": "./lib"
   },
   "engines": {
-    "node": "10.9.0",
-    "npm": "6.4.1"
+    "node": ">=10",
+    "npm": ">=6"
   },
   "dependencies": {
     "axios": "^0.18.0",


### PR DESCRIPTION
Currently using this package as a dependency requires very specific versions of `node` and `npm` packages. This PR tends to allow using `node>=10` and `npm>=6` to make sure this package is usable in wider scope of projects.